### PR TITLE
feat(plan): add plan of study index page

### DIFF
--- a/components/common/pages/sidebar/sidebar.tsx
+++ b/components/common/pages/sidebar/sidebar.tsx
@@ -30,7 +30,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 						icon="https://www.creative-tim.com/learning-lab/tailwind-starter-kit/img/team-4-470x470.png"
 						collapsed={!open}
 						value="PLAN OF STUDY"
-						href="/planofstudy"
+						href={`/plan/${userSession.openId}`}
 					/>
 					<SidebarItem
 						icon="https://www.creative-tim.com/learning-lab/tailwind-starter-kit/img/team-4-470x470.png"

--- a/pages/plan/[plan_id]/index.tsx
+++ b/pages/plan/[plan_id]/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Layout } from '@/common/pages/layouts/layout/layout';
+import { useSession } from 'next-auth/react';
+
+function PlanOfStudyIndexPage() {
+	const panelCount = [
+		"Modules",
+		"Communities",
+		"Grades",
+		"Account"
+	]
+	const {data:session} = useSession()
+	return (
+		<section className="flex flex-col stdcontainer">
+			<div className='flex flex-col mb-5'>
+			<h1 className="mb-3">plan of study</h1>
+			<h2 className="">Hi, <span className="uppercase">{session.user.name}</span>! Check out...</h2>
+			</div>
+			<div className='grid grid-cols-2 grid-rows-2 gap-x-6 gap-y-7'>
+				{panelCount.map((panel, index) => <PlanOfStudyPanel key={index} title={panel} body={"Lorem ipsum dolor sit amet, consectetur adipisicing elit. Expedita quasi, quo? A accusamus, debitis distinctio eos, est ipsam labore mollitia necessitatibus nemo odio odit perferendis quaerat quam quis repellendus sunt?"}/> )}
+			</div>
+		</section>
+	);
+}
+
+const PlanOfStudyPanel = ({title, body}) => {
+	return (
+		<div className='col-span-1 row-span-1 h-64 border border-wgray rounded-sm p-3'>
+			<h3>{title}</h3>
+			<p>{body}</p>
+		</div>
+	)
+}
+
+PlanOfStudyIndexPage.getLayout = function getLayout(page) {
+	return <Layout>{page}</Layout>
+}
+
+export default PlanOfStudyIndexPage;

--- a/pages/plan/[plan_id]/index.tsx
+++ b/pages/plan/[plan_id]/index.tsx
@@ -1,31 +1,37 @@
-import React from 'react';
-import { Layout } from '@/common/pages/layouts/layout/layout';
-import { useSession } from 'next-auth/react';
+import React from 'react'
+import { Layout } from '@/common/pages/layouts/layout/layout'
+import { useSession } from 'next-auth/react'
 
 function PlanOfStudyIndexPage() {
-	const panelCount = [
-		"Modules",
-		"Communities",
-		"Grades",
-		"Account"
-	]
-	const {data:session} = useSession()
+	const panelCount = ['Modules', 'Communities', 'Grades', 'Account']
+	const { data: session } = useSession()
 	return (
 		<section className="flex flex-col stdcontainer">
-			<div className='flex flex-col mb-5'>
-			<h1 className="mb-3">plan of study</h1>
-			<h2 className="">Hi, <span className="uppercase">{session.user.name}</span>! Check out...</h2>
+			<div className="flex flex-col mb-5">
+				<h1 className="mb-3">plan of study</h1>
+				<h2 className="">
+					Hi, <span className="uppercase">{session.user.name}</span>!
+					Check out...
+				</h2>
 			</div>
-			<div className='grid grid-cols-2 grid-rows-2 gap-x-6 gap-y-7'>
-				{panelCount.map((panel, index) => <PlanOfStudyPanel key={index} title={panel} body={"Lorem ipsum dolor sit amet, consectetur adipisicing elit. Expedita quasi, quo? A accusamus, debitis distinctio eos, est ipsam labore mollitia necessitatibus nemo odio odit perferendis quaerat quam quis repellendus sunt?"}/> )}
+			<div className="grid grid-cols-2 grid-rows-2 gap-x-6 gap-y-7">
+				{panelCount.map((panel, index) => (
+					<PlanOfStudyPanel
+						key={index}
+						title={panel}
+						body={
+							'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Expedita quasi, quo? A accusamus, debitis distinctio eos, est ipsam labore mollitia necessitatibus nemo odio odit perferendis quaerat quam quis repellendus sunt?'
+						}
+					/>
+				))}
 			</div>
 		</section>
-	);
+	)
 }
 
-const PlanOfStudyPanel = ({title, body}) => {
+const PlanOfStudyPanel = ({ title, body }) => {
 	return (
-		<div className='col-span-1 row-span-1 h-64 border border-wgray rounded-sm p-3'>
+		<div className="col-span-1 row-span-1 h-64 border border-wgray rounded-sm p-3">
 			<h3>{title}</h3>
 			<p>{body}</p>
 		</div>
@@ -36,4 +42,4 @@ PlanOfStudyIndexPage.getLayout = function getLayout(page) {
 	return <Layout>{page}</Layout>
 }
 
-export default PlanOfStudyIndexPage;
+export default PlanOfStudyIndexPage


### PR DESCRIPTION
1. updated sidebar link from `/planofstudy` to `/plan/[openID]/index`
2. created page based on **incomplete** design
3. created reusable panel as shown in the mock-up